### PR TITLE
Track the number of Cells opened since the player's Last Mistake

### DIFF
--- a/assets/scripts/objects/monster.gd
+++ b/assets/scripts/objects/monster.gd
@@ -19,6 +19,7 @@ func _get_source() -> Texture2D:
 
 
 func _reveal_active() -> void:
+	EffectManager.propagate(get_stage_instance().get_cell_effects().mistake_made, get_cell())
 	Quest.get_current().get_stats().damage(get_origin_stage().roll_power(), self)
 
 

--- a/engine/resources/data_containers/cell/cell_data.gd
+++ b/engine/resources/data_containers/cell/cell_data.gd
@@ -184,6 +184,8 @@ func _propagate_open(active: bool = true, allow_loot: bool = true) -> void:
 			if c in visited or c in to_explore or c.is_visible() or c.is_flagged():
 				continue
 			to_explore.append(c)
+	
+	EffectManager.propagate(get_stage_instance().get_cell_effects().open_propagation_finished, visited)
 
 
 func shatter(texture: Texture2D) -> void:
@@ -645,6 +647,7 @@ func notify_second_interacted() -> void:
 
 class CellEffects extends EventBus:
 	signal opened(cell: CellData)
+	signal open_propagation_finished(cells: Array[CellData])
 	
 	signal aura_applied(aura: Aura)
 	signal aura_removed(aura: Aura)

--- a/engine/resources/data_containers/quest/quest_player_attributes.gd
+++ b/engine/resources/data_containers/quest/quest_player_attributes.gd
@@ -137,6 +137,9 @@ func _ready() -> void:
 			return RESEARCH_WEIGHT_MULT
 		return 1.0
 	)
+	
+	get_quest().get_cell_effects().open_propagation_finished.connect(increment_cells_counter)
+	get_quest().get_cell_effects().mistake_made.connect(reset_cells_counter)
 
 
 ## Returns whether the current [member research_subject] matches the given [ItemData].

--- a/engine/resources/data_containers/quest/quest_player_attributes.gd
+++ b/engine/resources/data_containers/quest/quest_player_attributes.gd
@@ -6,59 +6,70 @@ const RESEARCH_WEIGHT_MULT := 5.0
 # ==============================================================================
 @export var score := 0 :
 	set(value):
-		score = EffectManager.propagate_mutable(change_property, 1, &"score", value)
-		EffectManager.propagate(property_changed, &"score", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"score", value)
+		EffectManager.propagate(property_changed, &"score", new_value)
+		score = new_value
 		emit_changed()
 @export var cells_opened_since_mistake := 0 :
 	set(value):
-		cells_opened_since_mistake = EffectManager.propagate_mutable(change_property, 1, &"cells_opened_since_mistake", value)
-		EffectManager.propagate(property_changed, &"cells_opened_since_mistake", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"cells_opened_since_mistake", value)
+		EffectManager.propagate(property_changed, &"cells_opened_since_mistake", new_value)
+		cells_opened_since_mistake = new_value
 		emit_changed()
 @export var rare_loot_modifier := 1.0 :
 	set(value):
-		rare_loot_modifier = EffectManager.propagate_mutable(change_property, 1, &"rare_loot_modifier", value)
-		EffectManager.propagate(property_changed, &"rare_loot_modifier", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"rare_loot_modifier", value)
+		EffectManager.propagate(property_changed, &"rare_loot_modifier", new_value)
+		rare_loot_modifier = new_value
 		emit_changed()
 @export var morality := 0 :
 	set(value):
-		morality = EffectManager.propagate_mutable(change_property, 1, &"morality", value)
-		EffectManager.propagate(property_changed, &"morality", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"morality", value)
+		EffectManager.propagate(property_changed, &"morality", new_value)
+		morality = new_value
 		emit_changed()
 @export var chests_opened := 0 :
 	set(value):
-		chests_opened = EffectManager.propagate_mutable(change_property, 1, &"chests_opened", value)
-		EffectManager.propagate(property_changed, &"chests_opened", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"chests_opened", value)
+		EffectManager.propagate(property_changed, &"chests_opened", new_value)
+		chests_opened = new_value
 		emit_changed()
 @export var monsters_killed := 0 :
 	set(value):
-		monsters_killed = EffectManager.propagate_mutable(change_property, 1, &"monsters_killed", value)
-		EffectManager.propagate(property_changed, &"monsters_killed", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"monsters_killed", value)
+		EffectManager.propagate(property_changed, &"monsters_killed", new_value)
+		monsters_killed = new_value
 		emit_changed()
 @export var mastery_activations := 0 :
 	set(value):
-		mastery_activations = EffectManager.propagate_mutable(change_property, 1, &"mastery_activations", value)
-		EffectManager.propagate(property_changed, &"mastery_activations", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"mastery_activations", value)
+		EffectManager.propagate(property_changed, &"mastery_activations", new_value)
+		mastery_activations = new_value
 		emit_changed()
 @export var pathfinding := 0 :
 	set(value):
-		pathfinding = EffectManager.propagate_mutable(change_property, 1, &"pathfinding", value)
-		EffectManager.propagate(property_changed, &"pathfinding", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"pathfinding", value)
+		EffectManager.propagate(property_changed, &"pathfinding", new_value)
+		pathfinding = new_value
 		emit_changed()
 @export var powerchording := 0 :
 	set(value):
-		powerchording = EffectManager.propagate_mutable(change_property, 1, &"powerchording", value)
-		EffectManager.propagate(property_changed, &"powerchording", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"powerchording", value)
+		EffectManager.propagate(property_changed, &"powerchording", new_value)
+		powerchording = new_value
 		emit_changed()
 @export_subgroup("Chain", "chain_")
 @export var chain_value := 0 :
 	set(value):
-		chain_value = EffectManager.propagate_mutable(change_property, 1, &"chain_value", value)
-		EffectManager.propagate(property_changed, &"chain_value", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"chain_value", value)
+		EffectManager.propagate(property_changed, &"chain_value", new_value)
+		chain_value = new_value
 		emit_changed()
 @export var chain_length := 0 :
 	set(value):
-		chain_length = EffectManager.propagate_mutable(change_property, 1, &"chain_length", value)
-		EffectManager.propagate(property_changed, &"chain_length", score)
+		var new_value = EffectManager.propagate_mutable(change_property, 1, &"chain_length", value)
+		EffectManager.propagate(property_changed, &"chain_length", new_value)
+		chain_length = new_value
 		emit_changed()
 
 @export var research_subject := "" :

--- a/engine/resources/data_containers/quest/quest_player_attributes.gd
+++ b/engine/resources/data_containers/quest/quest_player_attributes.gd
@@ -136,3 +136,11 @@ func item_matches_research(item: ItemData) -> bool:
 	var description := TranslationServer.translate(item.description)
 	TranslationServer.set_locale(locale)
 	return research_subject.to_lower() in description.to_lower()
+
+
+func reset_cells_counter(_cell: CellData):
+	cells_opened_since_mistake = 0
+
+
+func increment_cells_counter(_cell: CellData):
+	cells_opened_since_mistake += 1

--- a/engine/resources/data_containers/quest/quest_player_attributes.gd
+++ b/engine/resources/data_containers/quest/quest_player_attributes.gd
@@ -6,70 +6,70 @@ const RESEARCH_WEIGHT_MULT := 5.0
 # ==============================================================================
 @export var score := 0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"score", value)
-		EffectManager.propagate(property_changed, &"score", new_value)
-		score = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"score", value)
+		EffectManager.propagate(property_changed, &"score", value)
+		score = value
 		emit_changed()
 @export var cells_opened_since_mistake := 0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"cells_opened_since_mistake", value)
-		EffectManager.propagate(property_changed, &"cells_opened_since_mistake", new_value)
-		cells_opened_since_mistake = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"cells_opened_since_mistake", value)
+		EffectManager.propagate(property_changed, &"cells_opened_since_mistake", value)
+		cells_opened_since_mistake = value
 		emit_changed()
 @export var rare_loot_modifier := 1.0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"rare_loot_modifier", value)
-		EffectManager.propagate(property_changed, &"rare_loot_modifier", new_value)
-		rare_loot_modifier = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"rare_loot_modifier", value)
+		EffectManager.propagate(property_changed, &"rare_loot_modifier", value)
+		rare_loot_modifier = value
 		emit_changed()
 @export var morality := 0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"morality", value)
-		EffectManager.propagate(property_changed, &"morality", new_value)
-		morality = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"morality", value)
+		EffectManager.propagate(property_changed, &"morality", value)
+		morality = value
 		emit_changed()
 @export var chests_opened := 0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"chests_opened", value)
-		EffectManager.propagate(property_changed, &"chests_opened", new_value)
-		chests_opened = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"chests_opened", value)
+		EffectManager.propagate(property_changed, &"chests_opened", value)
+		chests_opened = value
 		emit_changed()
 @export var monsters_killed := 0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"monsters_killed", value)
-		EffectManager.propagate(property_changed, &"monsters_killed", new_value)
-		monsters_killed = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"monsters_killed", value)
+		EffectManager.propagate(property_changed, &"monsters_killed", value)
+		monsters_killed = value
 		emit_changed()
 @export var mastery_activations := 0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"mastery_activations", value)
-		EffectManager.propagate(property_changed, &"mastery_activations", new_value)
-		mastery_activations = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"mastery_activations", value)
+		EffectManager.propagate(property_changed, &"mastery_activations", value)
+		mastery_activations = value
 		emit_changed()
 @export var pathfinding := 0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"pathfinding", value)
-		EffectManager.propagate(property_changed, &"pathfinding", new_value)
-		pathfinding = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"pathfinding", value)
+		EffectManager.propagate(property_changed, &"pathfinding", value)
+		pathfinding = value
 		emit_changed()
 @export var powerchording := 0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"powerchording", value)
-		EffectManager.propagate(property_changed, &"powerchording", new_value)
-		powerchording = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"powerchording", value)
+		EffectManager.propagate(property_changed, &"powerchording", value)
+		powerchording = value
 		emit_changed()
 @export_subgroup("Chain", "chain_")
 @export var chain_value := 0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"chain_value", value)
-		EffectManager.propagate(property_changed, &"chain_value", new_value)
-		chain_value = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"chain_value", value)
+		EffectManager.propagate(property_changed, &"chain_value", value)
+		chain_value = value
 		emit_changed()
 @export var chain_length := 0 :
 	set(value):
-		var new_value = EffectManager.propagate_mutable(change_property, 1, &"chain_length", value)
-		EffectManager.propagate(property_changed, &"chain_length", new_value)
-		chain_length = new_value
+		value = EffectManager.propagate_mutable(change_property, 1, &"chain_length", value)
+		EffectManager.propagate(property_changed, &"chain_length", value)
+		chain_length = value
 		emit_changed()
 
 @export var research_subject := "" :
@@ -140,6 +140,12 @@ func _ready() -> void:
 
 
 func _enter_tree() -> void:
+	var base := get_parent()
+	while base != null:
+		if not base.is_node_ready():
+			await base.ready
+		base = base.get_parent()
+	
 	get_quest().get_cell_effects().open_propagation_finished.connect(increment_cells_counter)
 	get_quest().get_cell_effects().mistake_made.connect(reset_cells_counter)
 

--- a/engine/resources/data_containers/quest/quest_player_attributes.gd
+++ b/engine/resources/data_containers/quest/quest_player_attributes.gd
@@ -153,5 +153,5 @@ func reset_cells_counter(_cell: CellData):
 	cells_opened_since_mistake = 0
 
 
-func increment_cells_counter(_cell: CellData):
-	cells_opened_since_mistake += 1
+func increment_cells_counter(cells: Array[CellData]):
+	cells_opened_since_mistake += len(cells)

--- a/engine/resources/data_containers/quest/quest_player_attributes.gd
+++ b/engine/resources/data_containers/quest/quest_player_attributes.gd
@@ -137,9 +137,16 @@ func _ready() -> void:
 			return RESEARCH_WEIGHT_MULT
 		return 1.0
 	)
-	
+
+
+func _enter_tree() -> void:
 	get_quest().get_cell_effects().open_propagation_finished.connect(increment_cells_counter)
 	get_quest().get_cell_effects().mistake_made.connect(reset_cells_counter)
+
+
+func _exit_tree() -> void:
+	get_quest().get_cell_effects().open_propagation_finished.disconnect(increment_cells_counter)
+	get_quest().get_cell_effects().mistake_made.disconnect(reset_cells_counter)
 
 
 ## Returns whether the current [member research_subject] matches the given [ItemData].

--- a/engine/resources/data_containers/stage/stage_instance.gd
+++ b/engine/resources/data_containers/stage/stage_instance.gd
@@ -59,8 +59,6 @@ func _ready() -> void:
 		data.changed.connect(emit_changed)
 		get_grid().add_child(data)
 	
-	get_cell_effects().open_propagation_finished.connect(get_quest().get_attributes().increment_cells_counter)
-	get_cell_effects().mistake_made.connect(get_quest().get_attributes().reset_cells_counter)
 	emit_changed()
 
 
@@ -148,7 +146,6 @@ func generate(start_cell: CellData) -> void:
 		get_cells()[idx].set_object(Monster.new(get_stage()))
 	
 	var objects: Array[CellObject] = EffectManager.propagate_mutable(get_effects().get_guaranteed_objects, 0, [] as Array[CellObject])
-	objects.append(Wishpool.new())
 	var cells: Array[CellData] = []
 	cells.assign(get_cells().filter(func(cell: CellData) -> bool: return cell.is_empty()))
 	var picked := PackedInt32Array()

--- a/engine/resources/data_containers/stage/stage_instance.gd
+++ b/engine/resources/data_containers/stage/stage_instance.gd
@@ -59,7 +59,7 @@ func _ready() -> void:
 		data.changed.connect(emit_changed)
 		get_grid().add_child(data)
 	
-	get_cell_effects().opened.connect(get_quest().get_attributes().increment_cells_counter)
+	get_cell_effects().open_propagation_finished.connect(get_quest().get_attributes().increment_cells_counter)
 	get_cell_effects().mistake_made.connect(get_quest().get_attributes().reset_cells_counter)
 	emit_changed()
 
@@ -148,6 +148,7 @@ func generate(start_cell: CellData) -> void:
 		get_cells()[idx].set_object(Monster.new(get_stage()))
 	
 	var objects: Array[CellObject] = EffectManager.propagate_mutable(get_effects().get_guaranteed_objects, 0, [] as Array[CellObject])
+	objects.append(Wishpool.new())
 	var cells: Array[CellData] = []
 	cells.assign(get_cells().filter(func(cell: CellData) -> bool: return cell.is_empty()))
 	var picked := PackedInt32Array()

--- a/engine/resources/data_containers/stage/stage_instance.gd
+++ b/engine/resources/data_containers/stage/stage_instance.gd
@@ -59,6 +59,8 @@ func _ready() -> void:
 		data.changed.connect(emit_changed)
 		get_grid().add_child(data)
 	
+	get_quest().get_attributes().change_property.connect(count_first_opened_cell)
+	
 	emit_changed()
 
 
@@ -441,6 +443,13 @@ func solve_cell() -> CellData:
 
 func pass_turn() -> void:
 	EffectManager.propagate(get_effects().turn)
+
+
+func count_first_opened_cell(property: StringName, value: int) -> int:
+	if property == &"cells_opened_since_mistake":
+		get_quest().get_attributes().change_property.disconnect(count_first_opened_cell)
+		return get_quest().get_attributes().cells_opened_since_mistake + 1
+	return value
 
 
 ## Returns whether this [StageInstance] has been generated. If this is not the

--- a/engine/resources/data_containers/stage/stage_instance.gd
+++ b/engine/resources/data_containers/stage/stage_instance.gd
@@ -59,7 +59,7 @@ func _ready() -> void:
 		data.changed.connect(emit_changed)
 		get_grid().add_child(data)
 	
-	get_quest().get_attributes().change_property.connect(count_first_opened_cell)
+	get_quest().get_attributes().change_property.connect(_on_change_attribute)
 	
 	emit_changed()
 
@@ -445,11 +445,15 @@ func pass_turn() -> void:
 	EffectManager.propagate(get_effects().turn)
 
 
-func count_first_opened_cell(property: StringName, value: int) -> int:
-	if property == &"cells_opened_since_mistake":
-		get_quest().get_attributes().change_property.disconnect(count_first_opened_cell)
-		return get_quest().get_attributes().cells_opened_since_mistake + 1
+func _on_change_attribute(attribute: StringName, value: Variant) -> Variant:
+	if attribute == &"cells_opened_since_mistake":
+		return count_first_opened_cell()
 	return value
+
+
+func count_first_opened_cell() -> int:
+	get_quest().get_attributes().change_property.disconnect(_on_change_attribute)
+	return get_quest().get_attributes().cells_opened_since_mistake + 1
 
 
 ## Returns whether this [StageInstance] has been generated. If this is not the

--- a/engine/resources/data_containers/stage/stage_instance.gd
+++ b/engine/resources/data_containers/stage/stage_instance.gd
@@ -59,6 +59,8 @@ func _ready() -> void:
 		data.changed.connect(emit_changed)
 		get_grid().add_child(data)
 	
+	get_cell_effects().opened.connect(get_quest().get_attributes().increment_cells_counter)
+	get_cell_effects().mistake_made.connect(get_quest().get_attributes().reset_cells_counter)
 	emit_changed()
 
 


### PR DESCRIPTION
This PR allows the Quest Player Attributes node to track the number of cells the player has opened since their last mistake, and resets this value on each mistake.
## Implementation Details
### Cell Effect `open_propagation_finished`
The player can open Many cells in one click. Listening for single cells being opened and reacting to each is reliable, but ends up creating extra traffic through the EffectManager. This gets doubled when pushed through the Quest Player Attributes object, as it emits 2 Additional Signals in response to any of its value changes.
This signal is emitted at the end of `_propagate_open`, sending a reference to each opened cell in a single batch. Consumers can `map` / `for cell` as needed.
### Replicate Original "First Open" Cell Count
The original game counts the first batch of cells opened on any given stage as 1 Cell for the sake of the counter. Whether this is an intentional point of balance or just an implementation detail, I've replicated the behavior with a one-off signal receiver.